### PR TITLE
Squelch warnings from julia v0.4

### DIFF
--- a/src/FlatBuffers.jl
+++ b/src/FlatBuffers.jl
@@ -176,7 +176,7 @@ end
 # fallback which recursively calls read
 function getvalue{T}(t, o, ::Type{T})
     if isstruct(T)
-        if any(map(x->x<:Enum, T.types))
+        if any(x -> x <: Enum, T.types)
             args = []
             o = t.pos + o + 1
             for typ in T.types

--- a/test/monster.jl
+++ b/test/monster.jl
@@ -1,4 +1,8 @@
 module Example
+# Compat
+if !isdefined(Core, :String)
+    typealias String UTF8String
+end
 
 include(joinpath(Pkg.dir("FlatBuffers"), "src/header.jl"))
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,11 @@
 using FlatBuffers
 using Base.Test
 
+# Compat
+if !isdefined(Core, :String)
+    typealias String UTF8String
+end
+
 include(joinpath(Pkg.dir("FlatBuffers"), "test/internals.jl"))
 CheckByteLayout()
 CheckManualBuild()


### PR DESCRIPTION
There were some cases in tests where `String` was used without redefining it.