### PR TITLE
don't use Pkg.dir

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,7 +5,7 @@ if !isdefined(Core, :String)
     typealias String UTF8String
 end
 
-include(joinpath(Pkg.dir("FlatBuffers"), "test/internals.jl"))
+include("internals.jl")
 CheckByteLayout()
 CheckManualBuild()
 CheckVtableDeduplication()
@@ -17,7 +17,7 @@ CheckFinishedBytesError()
 CheckCreateByteVector()
 checkFuzz(100, 100, true)
 
-include(joinpath(Pkg.dir("FlatBuffers"), "test/monster.jl"))
+include("monster.jl")
 
 vec3 = Example.Vec3(1.0, 2.0, 3.0, 3.0, Example.Color(1), Example.Test(5, 6))
 test4 = Example.Test[Example.Test(10, 20), Example.Test(30, 40)]


### PR DESCRIPTION
that prevents the package from passing its tests if installed anywhere else
if this wasn't just calling `include`, you could use `dirname(@__FILE__)` instead